### PR TITLE
docs: Add drupal/storage to Editorial modules suggestions

### DIFF
--- a/pages/build/modules-themes-distributions.en.mdx
+++ b/pages/build/modules-themes-distributions.en.mdx
@@ -36,6 +36,7 @@ Modules are providing most of the time a single feature. They can work on their 
 | [Layout Builder](https://www.drupal.org/docs/8/core/modules/layout-builder) (core) | Allows content editors and site builders to easily and quickly create visual layouts for content display |
 | [Paragraphs](https://www.drupal.org/project/paragraphs)                  | Instead of putting all their content in one WYSIWYG body field including images and videos, end-users can now choose on-the-fly between pre-defined Paragraph Types independent from one another |
 | [Gutenberg](https://www.drupal.org/project/gutenberg)                    | Brings the powerful admin features of Gutenberg Editor |
+| [Storage](https://www.drupal.org/project/storage)                        | Lightweight, fieldable, revisionable and translatable content entity type to manage data that does not logically fit into the concept of a node, paragraph or media entity |
 
 Gutenberg and Layout Builder are gaining growing support in the community
 - There is a plan to [decouple Layout Builder with React](https://www.previousnext.com.au/blog/what-if-pitching-decoupled-layout-builder)

--- a/pages/build/modules-themes-distributions.fr.mdx
+++ b/pages/build/modules-themes-distributions.fr.mdx
@@ -35,6 +35,7 @@ Les modules fournissent généralement une fonctionnalité spécifique. Ils peuv
 | [Layout Builder](https://www.drupal.org/docs/8/core/modules/layout-builder) (core) | Permet aux rédacteurs de contenu et aux constructeurs de site de créer facilement et rapidement des mises en page visuelles pour l'affichage du contenu |
 | [Paragraphs](https://www.drupal.org/project/paragraphs)                  | Au lieu de mettre tout leur contenu dans un champ de corps WYSIWYG comprenant des images et des vidéos, les utilisateurs finaux peuvent maintenant choisir dynamiquement parmi des types de paragraphes prédéfinis indépendants les uns des autres |
 | [Gutenberg](https://www.drupal.org/project/gutenberg)                    | Apporte les puissantes fonctionnalités d'administration de l'éditeur Gutenberg |
+| [Storage](https://www.drupal.org/project/storage)                        | Type d'entité de contenu léger, modifiable, avec révision et traduisible pour gérer des données qui ne correspondent pas directement au concept d'un nœud, d'un paragraphe ou d'un média |
 
 Gutenberg et Layout Builder bénéficient d'un soutien croissant au sein de la communauté.
 - Il y a un projet pour [découpler Layout Builder avec React](https://www.previousnext.com.au/blog/what-if-pitching-decoupled-layout-builder)


### PR DESCRIPTION
Add `drupal/storage` module as a suggestion under _Editorial modules_

Reason: I consider this module a more efficient, cleaner and better integrated alternative to _Paragraphs_ in many cases. 